### PR TITLE
fixed wrong arguments for getting paper task list

### DIFF
--- a/paperswithcode/client.py
+++ b/paperswithcode/client.py
@@ -155,7 +155,7 @@ class PapersWithCodeClient:
         Returns:
             List[Task]: List of task objects.
         """
-        return [Task(**t) for t in self.http.get(f"/papers/{paper_id}/tasks/")]
+        return [Task(**t) for t in self.http.get(f"/papers/{paper_id}/tasks/")['results']]
 
     @handler
     def paper_method_list(self, paper_id: str) -> List[Method]:


### PR DESCRIPTION
This PR fixes the following error:

```
import paperswithcode

client = paperswithcode.PapersWithCodeClient()
paper_id = 'opening-the-black-box-of-deep-neural-networks'
client.paper_task_list(paper_id)
```

> TypeError: ModelMetaclass object argument after ** must be a mapping, not str
